### PR TITLE
Let listener exit when using --address flag

### DIFF
--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -38,7 +38,7 @@ var listenCmd = &cobra.Command{
 			}
 		}
 
-		// Handle scan flag
+		// Broadcast MDNS service
 		endBroadcast := make(chan bool)
 		if scanFlag {
 			go func() {
@@ -74,8 +74,10 @@ var listenCmd = &cobra.Command{
 			os.Exit(-1)
 		}
 
-		// End broadcast
-		endBroadcast <- true
+		// End MDNS service broadcast
+		if scanFlag {
+			endBroadcast <- true
+		}
 
 		fmt.Printf("Sync completed successfully!\n")
 	},
@@ -83,6 +85,6 @@ var listenCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(listenCmd)
-	listenCmd.PersistentFlags().BoolP("scan", "s", true, "scan network for peer")
+	listenCmd.PersistentFlags().BoolP("scan", "s", false, "scan network for peer")
 	listenCmd.PersistentFlags().StringP("port", "p", "2000", "specify the port")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -88,7 +88,7 @@ Uses list of peers unless port flag is specified.`,
 
 func init() {
 	rootCmd.AddCommand(syncCmd)
-	syncCmd.PersistentFlags().BoolP("scan", "s", true, "scan network for peer and sync")
+	syncCmd.PersistentFlags().BoolP("scan", "s", false, "scan network for peer and sync")
 	syncCmd.PersistentFlags().StringP("address", "a", "", "sync with specific IP:PORT")
 	syncCmd.PersistentFlags().BoolP("peers", "p", false, "sync with registered peers")
 	syncCmd.MarkFlagsMutuallyExclusive("address", "scan", "peers")


### PR DESCRIPTION
## Changes made
- Only use endBroadcast channel if `scan` flag exists.
- Set scan to false by default. 